### PR TITLE
Data loader bug fixes

### DIFF
--- a/data/cifar10_data.py
+++ b/data/cifar10_data.py
@@ -103,7 +103,7 @@ class DataLoader(object):
             self.labels = self.labels[inds]
 
         # on last iteration reset the counter and raise StopIteration
-        if self.p + n > self.data.shape[0]:
+        if self.p >= self.data.shape[0]:
             self.reset() # reset for next time we get called
             raise StopIteration
 

--- a/data/cifar10_data.py
+++ b/data/cifar10_data.py
@@ -110,7 +110,7 @@ class DataLoader(object):
         # on intermediate iterations fetch the next batch
         x = self.data[self.p : self.p + n]
         y = self.labels[self.p : self.p + n]
-        self.p += self.batch_size
+        self.p += self.n
 
         if self.return_labels:
             return x,y

--- a/data/imagenet_data.py
+++ b/data/imagenet_data.py
@@ -129,7 +129,7 @@ class DataLoader(object):
 
         # on intermediate iterations fetch the next batch
         x = self.data[self.p : self.p + n]
-        self.p += self.batch_size
+        self.p += self.n
 
         return x
 

--- a/data/imagenet_data.py
+++ b/data/imagenet_data.py
@@ -123,7 +123,7 @@ class DataLoader(object):
             self.data = self.data[inds]
 
         # on last iteration reset the counter and raise StopIteration
-        if self.p + n > self.data.shape[0]:
+        if self.p >= self.data.shape[0]:
             self.reset() # reset for next time we get called
             raise StopIteration
 


### PR DESCRIPTION
Found two minor bugs in the data loader code, 1) the data index pointer was always advanced by the batch size even if a caller passed a value for n, and 2) the iterator would stop before reaching the end of the data in cases where the batch size did not evenly divide the data size (i.e., you'd skip the last batch).